### PR TITLE
Proof of concept: Update attrs from meta.yaml

### DIFF
--- a/.github/workflows/update_attrs.yaml
+++ b/.github/workflows/update_attrs.yaml
@@ -26,3 +26,6 @@ jobs:
           python scripts/update_attrs.py
         env:
           GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SHA: ${{ github.sha }}

--- a/.github/workflows/update_attrs.yaml
+++ b/.github/workflows/update_attrs.yaml
@@ -12,6 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: "Install dependencies"
+        run: |
+          python -m pip install --upgrade pip
+          pip install zarr gcsfs ruamel.yaml
       - name: "Authenticate to Google Cloud"
         id: "auth"
         uses: "google-github-actions/auth@v2"

--- a/feedstock/meta.yaml
+++ b/feedstock/meta.yaml
@@ -8,6 +8,9 @@ recipes:
   - id: "proto_b"
     object: "recipe:proto_b"
 
+  - id: "proto_missing"
+    object: "recipe:proto_missing"
+
 provenance:
   providers:
     - name: "Zenodo"

--- a/scripts/update_attrs.py
+++ b/scripts/update_attrs.py
@@ -11,7 +11,6 @@ from datetime import datetime, timezone
 fs = gcsfs.GCSFileSystem()
 
 # # For later, get the current git hash and add to the updated attribute
-git_hash = os.popen('git rev-parse HEAD').read().strip()
 timestamp = datetime.now(timezone.utc).isoformat()
 
 # read info from meta.yaml
@@ -52,7 +51,8 @@ for recipe in meta['recipes']:
     attr_updates = recipe | top_level_meta
     
     # Information for reproducibility
-    attr_updates['attrs_updated_git_hash'] = git_hash
-    attr_updates['attrs_updated_time_utc'] = timestamp 
+    attr_updates['attrs_updated_source'] = f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}/commit/{os.environ['GITHUB_SHA']}"
+    attr_updates['attrs_updated_time_utc'] = timestamp
+    
     check_path = update_zarr_attrs(store_path, attr_updates)
     print(f"Updated {check_path} with {attr_updates=}")

--- a/scripts/update_attrs.py
+++ b/scripts/update_attrs.py
@@ -9,7 +9,7 @@ yaml = YAML(typ='safe')
 # git_hash = os.popen('git rev-parse HEAD').read().strip()
 
 # read info from meta.yaml
-meta_path = '../feedstock/meta.yaml'
+meta_path = './feedstock/meta.yaml'
 meta = yaml.load(pathlib.Path(meta_path))
 
 # Loop over each recipe 

--- a/scripts/update_attrs.py
+++ b/scripts/update_attrs.py
@@ -12,10 +12,20 @@ fs = gcsfs.GCSFileSystem()
 
 # # For later, get the current git hash and add to the updated attribute
 git_hash = os.popen('git rev-parse HEAD').read().strip()
+timestamp = datetime.now(timezone.utc).isoformat()
 
 # read info from meta.yaml
 meta_path = './feedstock/meta.yaml'
 meta = yaml.load(pathlib.Path(meta_path))
+
+def update_zarr_attrs(store_path:str, additonal_attrs:dict):
+    """
+    Update the attributes of a zarr store with the given dictionary
+    """
+    store = zarr.open(zarr.storage.FSStore(pathlib.Path(store_path)), mode='a')
+    store.attrs.update(additonal_attrs)
+    zarr.convenience.consolidate_metadata(store_path) #Important: do not pass the store object here!
+    return store_path
 
 # Loop over each recipe 
 for recipe in meta['recipes']:
@@ -30,9 +40,6 @@ for recipe in meta['recipes']:
         print(f"Warning: Store {store_path} does not exist. Skipping.")
         continue
 
-    # Get the current store object
-    store = zarr.open(zarr.storage.FSStore(store_path), mode='a')
-
     # add the infor from the top level of the meta.yaml
     top_level_meta = {
             k: meta.get(k, 'none') for k in [
@@ -42,13 +49,10 @@ for recipe in meta['recipes']:
             ]
             }
 
-    meta_updates = recipe | top_level_meta
+    attr_updates = recipe | top_level_meta
     
     # Information for reproducibility
-    meta_updates['attrs_updated_git_hash'] = git_hash
-    meta_updates['attrs_updated_time_utc'] = datetime.now(timezone.utc).isoformat()
-    
-    store.attrs.update(meta_updates)
-    zarr.convenience.consolidate_metadata(store_path) #Important: do not pass the store object here!
-
-
+    attr_updates['attrs_updated_git_hash'] = git_hash
+    attr_updates['attrs_updated_time_utc'] = timestamp 
+    check_path = update_zarr_attrs(store_path, attr_updates)
+    print(f"Updated {check_path} with {attr_updates=}")

--- a/scripts/update_attrs.py
+++ b/scripts/update_attrs.py
@@ -6,7 +6,7 @@ import pathlib
 from ruamel.yaml import YAML
 yaml = YAML(typ='safe')
 import gcsfs
-import datetime
+from datetime import datetime, timezone
 
 fs = gcsfs.GCSFileSystem()
 
@@ -45,8 +45,8 @@ for recipe in meta['recipes']:
     meta_updates = recipe | top_level_meta
     
     # Information for reproducibility
-    meta_updates['git_hash_attrs_updated'] = git_hash
-    meta_updates['attrs_updated_time_utc'] = datetime.datetime.now(datetime.UTC).isoformat()
+    meta_updates['attrs_updated_git_hash'] = git_hash
+    meta_updates['attrs_updated_time_utc'] = datetime.now(timezone.utc).isoformat()
     
     store.attrs.update(meta_updates)
     zarr.convenience.consolidate_metadata(store_path) #Important: do not pass the store object here!

--- a/scripts/update_attrs.py
+++ b/scripts/update_attrs.py
@@ -1,15 +1,17 @@
 # This script updates the attributes of all the zarr stores that are created by the recipe, based on the current version of meta.yaml
 
 import zarr
+import os
 import pathlib
 from ruamel.yaml import YAML
 yaml = YAML(typ='safe')
 import gcsfs
+import datetime
 
 fs = gcsfs.GCSFileSystem()
 
 # # For later, get the current git hash and add to the updated attribute
-# git_hash = os.popen('git rev-parse HEAD').read().strip()
+git_hash = os.popen('git rev-parse HEAD').read().strip()
 
 # read info from meta.yaml
 meta_path = './feedstock/meta.yaml'
@@ -42,9 +44,9 @@ for recipe in meta['recipes']:
 
     meta_updates = recipe | top_level_meta
     
-    ## For later: Add the git hash as 'git_hash_attrs_updated'
-    # meta_updates['git_hash_attrs_updated'] = git_hash
-    meta_updates['git_hash_attrs_updated'] = 'some_fake_hash'
+    # Information for reproducibility
+    meta_updates['git_hash_attrs_updated'] = git_hash
+    meta_updates['attrs_updated_time_utc'] = datetime.datetime.now(datetime.UTC).isoformat()
     
     store.attrs.update(meta_updates)
     zarr.convenience.consolidate_metadata(store_path) #Important: do not pass the store object here!

--- a/scripts/update_attrs.py
+++ b/scripts/update_attrs.py
@@ -4,6 +4,9 @@ import zarr
 import pathlib
 from ruamel.yaml import YAML
 yaml = YAML(typ='safe')
+import gcsfs
+
+fs = gcsfs.GCSFileSystem()
 
 # # For later, get the current git hash and add to the updated attribute
 # git_hash = os.popen('git rev-parse HEAD').read().strip()
@@ -20,15 +23,13 @@ for recipe in meta['recipes']:
     # Some how get the store path from the recipe
     store_path = f'gs://leap-scratch/jbusecke/proto_feedstock/{id}.zarr' # how can I extract this for multiple recipes using the config files?
 
-    fsstore = zarr.storage.FSStore(store_path)
-
     # Check if store exists and otherwise give a useful warning
-    if not fsstore.exists(''):
+    if not fs.exists(store_path):
         print(f"Warning: Store {store_path} does not exist. Skipping.")
         continue
 
     # Get the current store object
-    store = zarr.open(fsstore, mode='a')
+    store = zarr.open(zarr.storage.FSStore(store_path), mode='a')
 
     # add the infor from the top level of the meta.yaml
     top_level_meta = {

--- a/scripts/update_attrs.py
+++ b/scripts/update_attrs.py
@@ -22,7 +22,7 @@ def update_zarr_attrs(store_path:str, additonal_attrs:dict):
     """
     Update the attributes of a zarr store with the given dictionary
     """
-    store = zarr.open(zarr.storage.FSStore(pathlib.Path(store_path)), mode='a')
+    store = zarr.open(zarr.storage.FSStore(store_path), mode='a')
     store.attrs.update(additonal_attrs)
     zarr.convenience.consolidate_metadata(store_path) #Important: do not pass the store object here!
     return store_path


### PR DESCRIPTION
Wohoo this works. 

I used this snipped on the LEAP hub to create 'fresh' stores on the scratch bucket:
```python
## test store output
for id in ['proto_a', 'proto_b']:
    ds = xr.open_dataset(f"gs://leap-scratch/jbusecke/proto_feedstock/{id}.zarr", engine="zarr")
    print(id)
    display(ds)
```

and then get:
```python
## test store output
for id in ['proto_a', 'proto_b']:
    ds = xr.open_dataset(f"gs://leap-scratch/jbusecke/proto_feedstock/{id}.zarr", engine="zarr")
    print(id)
    display(ds)
```
<img width="1249" alt="image" src="https://github.com/leap-stc/proto_feedstock/assets/14314623/9dcbd688-623e-450b-9bc4-00fe67989ad5">


## TODO:
- [ ] Parse current git hash from github action
- [ ] Parse the full prefix from somewhere? Config file? Might have to wait until the recipe is set up.