### PR TITLE
split reusable into jobs

### DIFF
--- a/.github/workflows/check_dataflow_jobs.yaml
+++ b/.github/workflows/check_dataflow_jobs.yaml
@@ -7,6 +7,10 @@ on:
         description: 'Dataflow job name to check'
         required: true
   workflow_call:
+    inputs:
+      jobname:
+        description: 'Dataflow job name to check'
+        required: true
     secrets:
       GCP_DATAFLOW_SERVICE_KEY:
         required: true
@@ -23,7 +27,7 @@ jobs:
         credentials_json: "${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}"
     - name: Wait for Dataflow jobs to finish
       run: |
-        jobname="$JOB_NAME"
+        jobname="${{ github.event.inputs.jobname }}"
         while true; do
           count=$(gcloud dataflow jobs list --status=active --filter="name:${jobname}" --format="value(id)" | wc -l)
           echo "Active Dataflow jobs: $count"

--- a/.github/workflows/check_dataflow_jobs.yaml
+++ b/.github/workflows/check_dataflow_jobs.yaml
@@ -6,11 +6,12 @@ on:
       jobname:
         description: 'Dataflow job name to check'
         required: true
-  workflow_call:
+  workflow_call: # i cant make this work at any freakding cost... for now just call it manually
     inputs:
       jobname:
         description: 'Dataflow job name to check'
         required: true
+        type: string # not sure if that gives all the trouble...
     secrets:
       GCP_DATAFLOW_SERVICE_KEY:
         required: true
@@ -28,16 +29,16 @@ jobs:
     - name: Print the env.JOB_NAME
       run: |
         echo "JOB_NAME: ${{ env.JOB_NAME }}"
-    # - name: Wait for Dataflow jobs to finish
-    #   run: |
-    #     jobname="${{ github.event.inputs.jobname }}"
-    #     while true; do
-    #       count=$(gcloud dataflow jobs list --status=active --filter="name:${jobname}" --format="value(id)" | wc -l)
-    #       echo "Active Dataflow jobs: $count"
-    #       if [ "$count" -eq "0" ]; then
-    #         echo "No active Dataflow jobs found."
-    #         break
-    #       fi
-    #       echo "Waiting for Dataflow jobs to finish..."
-    #       sleep 30
-    #     done
+    - name: Wait for Dataflow jobs to finish
+      run: |
+        jobname="${{ github.event.inputs.jobname }}"
+        while true; do
+          count=$(gcloud dataflow jobs list --status=active --filter="name:${jobname}" --format="value(id)" | wc -l)
+          echo "Active Dataflow jobs: $count"
+          if [ "$count" -eq "0" ]; then
+            echo "No active Dataflow jobs found."
+            break
+          fi
+          echo "Waiting for Dataflow jobs to finish..."
+          sleep 30
+        done

--- a/.github/workflows/check_dataflow_jobs.yaml
+++ b/.github/workflows/check_dataflow_jobs.yaml
@@ -7,6 +7,13 @@ on:
         description: 'Dataflow job name to check'
         required: true
         default: ''
+  workflow_call:
+    inputs:
+      jobname:
+        description: 'Dataflow job name to check'
+        required: true
+        default: ''
+        type: string
 
 jobs:
   check-jobs:

--- a/.github/workflows/check_dataflow_jobs.yaml
+++ b/.github/workflows/check_dataflow_jobs.yaml
@@ -26,7 +26,8 @@ jobs:
       with:
         credentials_json: "${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}"
     - name: Print the env.JOB_NAME
-      run: echo "JOB_NAME: ${{ env.JOB_NAME }}"
+      run: |
+        echo "JOB_NAME: ${{ env.JOB_NAME }}"
     # - name: Wait for Dataflow jobs to finish
     #   run: |
     #     jobname="${{ github.event.inputs.jobname }}"

--- a/.github/workflows/check_dataflow_jobs.yaml
+++ b/.github/workflows/check_dataflow_jobs.yaml
@@ -6,13 +6,11 @@ on:
       jobname:
         description: 'Dataflow job name to check'
         required: true
-        default: ''
   workflow_call:
     inputs:
       jobname:
         description: 'Dataflow job name to check'
         required: true
-        default: ''
         type: string
     secrets:
       GCP_DATAFLOW_SERVICE_KEY:

--- a/.github/workflows/check_dataflow_jobs.yaml
+++ b/.github/workflows/check_dataflow_jobs.yaml
@@ -25,16 +25,18 @@ jobs:
       uses: "google-github-actions/auth@v2"
       with:
         credentials_json: "${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}"
-    - name: Wait for Dataflow jobs to finish
-      run: |
-        jobname="${{ github.event.inputs.jobname }}"
-        while true; do
-          count=$(gcloud dataflow jobs list --status=active --filter="name:${jobname}" --format="value(id)" | wc -l)
-          echo "Active Dataflow jobs: $count"
-          if [ "$count" -eq "0" ]; then
-            echo "No active Dataflow jobs found."
-            break
-          fi
-          echo "Waiting for Dataflow jobs to finish..."
-          sleep 30
-        done
+    - name: Print the env.JOB_NAME
+      run: echo "JOB_NAME: ${{ env.JOB_NAME }}"
+    # - name: Wait for Dataflow jobs to finish
+    #   run: |
+    #     jobname="${{ github.event.inputs.jobname }}"
+    #     while true; do
+    #       count=$(gcloud dataflow jobs list --status=active --filter="name:${jobname}" --format="value(id)" | wc -l)
+    #       echo "Active Dataflow jobs: $count"
+    #       if [ "$count" -eq "0" ]; then
+    #         echo "No active Dataflow jobs found."
+    #         break
+    #       fi
+    #       echo "Waiting for Dataflow jobs to finish..."
+    #       sleep 30
+    #     done

--- a/.github/workflows/check_dataflow_jobs.yaml
+++ b/.github/workflows/check_dataflow_jobs.yaml
@@ -14,6 +14,9 @@ on:
         required: true
         default: ''
         type: string
+    secrets:
+      GCP_DATAFLOW_SERVICE_KEY:
+        required: true
 
 jobs:
   check-jobs:

--- a/.github/workflows/check_dataflow_jobs.yaml
+++ b/.github/workflows/check_dataflow_jobs.yaml
@@ -7,11 +7,6 @@ on:
         description: 'Dataflow job name to check'
         required: true
   workflow_call:
-    inputs:
-      jobname:
-        description: 'Dataflow job name to check'
-        required: true
-        type: string
     secrets:
       GCP_DATAFLOW_SERVICE_KEY:
         required: true
@@ -28,7 +23,7 @@ jobs:
         credentials_json: "${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}"
     - name: Wait for Dataflow jobs to finish
       run: |
-        jobname="${{ github.event.inputs.jobname }}"
+        jobname="$JOB_NAME"
         while true; do
           count=$(gcloud dataflow jobs list --status=active --filter="name:${jobname}" --format="value(id)" | wc -l)
           echo "Active Dataflow jobs: $count"

--- a/.github/workflows/deploy_recipe.yaml
+++ b/.github/workflows/deploy_recipe.yaml
@@ -44,7 +44,7 @@ jobs:
       #     GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
   check-dataflow:
     needs: deploy-recipes
-    uses: leap-stc/proto_feedstock/.github/workflows/check_dataflow_jobs.yaml@main
+    uses: leap-stc/proto_feedstock/.github/workflows/check_dataflow_jobs.yaml
     with:
       jobname: $JOB_NAME
   just-another-job:

--- a/.github/workflows/deploy_recipe.yaml
+++ b/.github/workflows/deploy_recipe.yaml
@@ -20,9 +20,7 @@ jobs:
         run: |
           echo "Job Name: $JOB_NAME"
   deploy-recipes:
-    name: deploy-recipes
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
       - name: "Authenticate to Google Cloud"
@@ -34,20 +32,18 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pangeo-forge-runner
-      - name: "Check if the workflows are there?"
-        run: |
-          ls -la .github/workflows
       - name: "Deploy recipes"
         run: |
           pangeo-forge-runner bake \
             --repo=${{ github.server_url }}/${{ github.repository }}.git \
             --ref=${{ github.sha }} \
             --feedstock-subdir='feedstock' \
-            --Bake.job_name="$JOB_NAME" \
+            --Bake.job_name=$JOB_NAME \
             --Bake.recipe_id=${{ github.event.inputs.recipe_id }} \
             -f configs/config_dataflow.py
         env:
           GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
+          JOB_NAME: ${{ github.event.inputs.recipe_id }}-${{ github.run_id }}-${{ github.run_attempt }}
   check-dataflow:
     needs: deploy-recipes
     uses: leap-stc/proto_feedstock/.github/workflows/check_dataflow_jobs.yaml@chain-jobs

--- a/.github/workflows/deploy_recipe.yaml
+++ b/.github/workflows/deploy_recipe.yaml
@@ -44,13 +44,13 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
   check-dataflow:
     needs: deploy-recipes
-    uses: ./proto_feedstock/.github/workflows/check_dataflow_jobs.yaml
+    uses: leap-stc/proto_feedstock/.github/workflows/check_dataflow_jobs.yaml@chain-jobs
     with:
       jobname: $JOB_NAME
     secrets:
       GCP_DATAFLOW_SERVICE_KEY: ${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}
   update-attrs:
     needs: check-dataflow
-    uses: ./.github/workflows/update_attrs.yaml
+    uses: leap-stc/proto_feedstock/.github/workflows/update_attrs.yaml@chain-jobs
     secrets:
       GCP_DATAFLOW_SERVICE_KEY: ${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}

--- a/.github/workflows/deploy_recipe.yaml
+++ b/.github/workflows/deploy_recipe.yaml
@@ -42,12 +42,14 @@ jobs:
       #       -f configs/config_dataflow.py
       #   env:
       #     GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
-    check-dataflow:
-      needs: deploy-recipes
-      uses: leap-stc/proto_feedstock/.github/workflows/check_dataflow_jobs.yaml@main
-      with:
-        jobname: $JOB_NAME
-    just-another-step:
-      - name: Just something else
+  check-dataflow:
+    needs: deploy-recipes
+    uses: leap-stc/proto_feedstock/.github/workflows/check_dataflow_jobs.yaml@main
+    with:
+      jobname: $JOB_NAME
+  just-another-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Just another step
         run: echo "This is just another step"
       

--- a/.github/workflows/deploy_recipe.yaml
+++ b/.github/workflows/deploy_recipe.yaml
@@ -41,7 +41,7 @@ jobs:
     needs: deploy-recipes
     uses: ./.github/workflows/check_dataflow_jobs.yaml
     with:
-      jobname: ${{ env.JOB_NAME }}
+      jobname: "$JOB_NAME"
     secrets:
       GCP_DATAFLOW_SERVICE_KEY: ${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}
   update-attrs:

--- a/.github/workflows/deploy_recipe.yaml
+++ b/.github/workflows/deploy_recipe.yaml
@@ -22,24 +22,24 @@ jobs:
         uses: "google-github-actions/auth@v2"
         with:
           credentials_json: "${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}"
-      # - name: "Install dependencies"
-      #   run: |
-      #     python -m pip install --upgrade pip
-      #     pip install pangeo-forge-runner
-      # - name: "Deploy recipes"
-      #   run: |
-      #     pangeo-forge-runner bake \
-      #       --repo=${{ github.server_url }}/${{ github.repository }}.git \
-      #       --ref=${{ github.sha }} \
-      #       --feedstock-subdir='feedstock' \
-      #       --Bake.job_name=${{ env.JOB_NAME }} \
-      #       --Bake.recipe_id=${{ github.event.inputs.recipe_id }} \
-      #       -f configs/config_dataflow.py
-      #   env:
-      #     GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
+      - name: "Install dependencies"
+        run: |
+          python -m pip install --upgrade pip
+          pip install pangeo-forge-runner
+      - name: "Deploy recipes"
+        run: |
+          pangeo-forge-runner bake \
+            --repo=${{ github.server_url }}/${{ github.repository }}.git \
+            --ref=${{ github.sha }} \
+            --feedstock-subdir='feedstock' \
+            --Bake.job_name=${{ env.JOB_NAME }} \
+            --Bake.recipe_id=${{ github.event.inputs.recipe_id }} \
+            -f configs/config_dataflow.py
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
       - name: Wait for Dataflow jobs to finish
-      # I tried to make this reusable but the fucking thing would not accept env.JOB_NAME as input.
-      # AT that point, screw it, not worth it.
+        # I tried to make this reusable but the fucking thing would not accept env.JOB_NAME as input.
+        # AT that point, screw it, not worth it.
         run: |
           jobname="${{ env.JOB_NAME }}"
           while true; do

--- a/.github/workflows/deploy_recipe.yaml
+++ b/.github/workflows/deploy_recipe.yaml
@@ -40,8 +40,6 @@ jobs:
   check-dataflow:
     needs: deploy-recipes
     uses: ./.github/workflows/check_dataflow_jobs.yaml
-    with:
-      jobname: ${{ github.event.inputs.recipe_id }}-${{ github.run_id }}-${{ github.run_attempt }}
     secrets:
       GCP_DATAFLOW_SERVICE_KEY: ${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}
   update-attrs:

--- a/.github/workflows/deploy_recipe.yaml
+++ b/.github/workflows/deploy_recipe.yaml
@@ -47,7 +47,10 @@ jobs:
     uses: leap-stc/proto_feedstock/.github/workflows/check_dataflow_jobs.yaml@chain-jobs
     with:
       jobname: $JOB_NAME
+    secrets:
+      GCP_DATAFLOW_SERVICE_KEY: ${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}
   just-another-job:
+    needs: check-dataflow
     runs-on: ubuntu-latest
     steps:
       - name: Just another step

--- a/.github/workflows/deploy_recipe.yaml
+++ b/.github/workflows/deploy_recipe.yaml
@@ -19,45 +19,45 @@ jobs:
       - name: "Print Job Name"
         run: |
           echo "Job Name: $JOB_NAME"
-  # deploy-recipes:
-  #   name: deploy-recipes
-  #   runs-on: ubuntu-latest
+  deploy-recipes:
+    name: deploy-recipes
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: "Authenticate to Google Cloud"
-  #       id: "auth"
-  #       uses: "google-github-actions/auth@v2"
-  #       with:
-  #         credentials_json: "${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}"
-  #     - name: "Install dependencies"
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         pip install pangeo-forge-runner
-  #     - name: "Check if the workflows are there?"
-  #       run: |
-  #         ls -la .github/workflows
-  #     - name: "Deploy recipes"
-  #       run: |
-  #         pangeo-forge-runner bake \
-  #           --repo=${{ github.server_url }}/${{ github.repository }}.git \
-  #           --ref=${{ github.sha }} \
-  #           --feedstock-subdir='feedstock' \
-  #           --Bake.job_name=$JOB_NAME \
-  #           --Bake.recipe_id=${{ github.event.inputs.recipe_id }} \
-  #           -f configs/config_dataflow.py
-  #       env:
-  #         GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
-  # check-dataflow:
-  #   needs: deploy-recipes
-  #   uses: leap-stc/proto_feedstock/.github/workflows/check_dataflow_jobs.yaml@chain-jobs
-  #   with:
-  #     jobname: $JOB_NAME
-  #   secrets:
-  #     GCP_DATAFLOW_SERVICE_KEY: ${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}
-  # update-attrs:
-  #   needs: check-dataflow
-  #   uses: leap-stc/proto_feedstock/.github/workflows/update_attrs.yaml@chain-jobs
-  #   # I want these to be referenced locally (https://github.blog/changelog/2022-01-25-github-actions-reusable-workflows-can-be-referenced-locally/)
-  #   secrets:
-  #     GCP_DATAFLOW_SERVICE_KEY: ${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Authenticate to Google Cloud"
+        id: "auth"
+        uses: "google-github-actions/auth@v2"
+        with:
+          credentials_json: "${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}"
+      - name: "Install dependencies"
+        run: |
+          python -m pip install --upgrade pip
+          pip install pangeo-forge-runner
+      - name: "Check if the workflows are there?"
+        run: |
+          ls -la .github/workflows
+      - name: "Deploy recipes"
+        run: |
+          pangeo-forge-runner bake \
+            --repo=${{ github.server_url }}/${{ github.repository }}.git \
+            --ref=${{ github.sha }} \
+            --feedstock-subdir='feedstock' \
+            --Bake.job_name="$JOB_NAME" \
+            --Bake.recipe_id=${{ github.event.inputs.recipe_id }} \
+            -f configs/config_dataflow.py
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
+  check-dataflow:
+    needs: deploy-recipes
+    uses: leap-stc/proto_feedstock/.github/workflows/check_dataflow_jobs.yaml@chain-jobs
+    with:
+      jobname: $JOB_NAME
+    secrets:
+      GCP_DATAFLOW_SERVICE_KEY: ${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}
+  update-attrs:
+    needs: check-dataflow
+    uses: leap-stc/proto_feedstock/.github/workflows/update_attrs.yaml@chain-jobs
+    # I want these to be referenced locally (https://github.blog/changelog/2022-01-25-github-actions-reusable-workflows-can-be-referenced-locally/)
+    secrets:
+      GCP_DATAFLOW_SERVICE_KEY: ${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}

--- a/.github/workflows/deploy_recipe.yaml
+++ b/.github/workflows/deploy_recipe.yaml
@@ -44,13 +44,13 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
   check-dataflow:
     needs: deploy-recipes
-    uses: ./proto_feedstock/.github/workflows/check_dataflow_jobs.yaml@chain-jobs
+    uses: ./proto_feedstock/.github/workflows/check_dataflow_jobs.yaml
     with:
       jobname: $JOB_NAME
     secrets:
       GCP_DATAFLOW_SERVICE_KEY: ${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}
   update-attrs:
     needs: check-dataflow
-    uses: ./.github/workflows/update_attrs.yaml@chain-jobs
+    uses: ./.github/workflows/update_attrs.yaml
     secrets:
       GCP_DATAFLOW_SERVICE_KEY: ${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}

--- a/.github/workflows/deploy_recipe.yaml
+++ b/.github/workflows/deploy_recipe.yaml
@@ -55,6 +55,5 @@ jobs:
   update-attrs:
     needs: deploy-recipes
     uses: ./.github/workflows/update_attrs.yaml
-    # I want these to be referenced locally (https://github.blog/changelog/2022-01-25-github-actions-reusable-workflows-can-be-referenced-locally/)
     secrets:
       GCP_DATAFLOW_SERVICE_KEY: ${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}

--- a/.github/workflows/deploy_recipe.yaml
+++ b/.github/workflows/deploy_recipe.yaml
@@ -44,7 +44,7 @@ jobs:
       #     GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
   check-dataflow:
     needs: deploy-recipes
-    uses: leap-stc/proto_feedstock/.github/workflows/check_dataflow_jobs.yaml
+    uses: leap-stc/proto_feedstock/.github/workflows/check_dataflow_jobs.yaml@main
     with:
       jobname: $JOB_NAME
   just-another-job:

--- a/.github/workflows/deploy_recipe.yaml
+++ b/.github/workflows/deploy_recipe.yaml
@@ -42,6 +42,9 @@ jobs:
     uses: ./.github/workflows/check_dataflow_jobs.yaml
     secrets:
       GCP_DATAFLOW_SERVICE_KEY: ${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}
+    with:
+      env:
+        JOB_NAME: ${{ github.event.inputs.recipe_id }}-${{ github.run_id }}-${{ github.run_attempt }}
   update-attrs:
     needs: check-dataflow
     uses: ./.github/workflows/update_attrs.yaml

--- a/.github/workflows/deploy_recipe.yaml
+++ b/.github/workflows/deploy_recipe.yaml
@@ -42,10 +42,12 @@ jobs:
       #       -f configs/config_dataflow.py
       #   env:
       #     GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
-      - name: Wait for job completion
-        uses: leap-stc/proto_feedstock/.github/workflows/check_dataflow_jobs.yaml@main
-        with:
-          jobname: $JOB_NAME
+    check-dataflow:
+      needs: deploy-recipes
+      uses: leap-stc/proto_feedstock/.github/workflows/check_dataflow_jobs.yaml@main
+      with:
+        jobname: $JOB_NAME
+    just-another-step:
       - name: Just something else
         run: echo "This is just another step"
       

--- a/.github/workflows/deploy_recipe.yaml
+++ b/.github/workflows/deploy_recipe.yaml
@@ -44,11 +44,13 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
   check-dataflow:
     needs: deploy-recipes
-    uses: leap-stc/proto_feedstock/.github/workflows/check_dataflow_jobs.yaml@chain-jobs
+    uses: ./proto_feedstock/.github/workflows/check_dataflow_jobs.yaml@chain-jobs
     with:
       jobname: $JOB_NAME
     secrets:
       GCP_DATAFLOW_SERVICE_KEY: ${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}
   update-attrs:
     needs: check-dataflow
-    uses: leap-stc/proto_feedstock/.github/workflows/update_attrs.yaml@chain-jobs
+    uses: ./.github/workflows/update_attrs.yaml@chain-jobs
+    secrets:
+      GCP_DATAFLOW_SERVICE_KEY: ${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}

--- a/.github/workflows/deploy_recipe.yaml
+++ b/.github/workflows/deploy_recipe.yaml
@@ -37,17 +37,16 @@ jobs:
             -f configs/config_dataflow.py
         env:
           GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
-          JOB_NAME: ${{ github.event.inputs.recipe_id }}-${{ github.run_id }}-${{ github.run_attempt }}
   check-dataflow:
     needs: deploy-recipes
-    uses: leap-stc/proto_feedstock/.github/workflows/check_dataflow_jobs.yaml@chain-jobs
+    uses: ./.github/workflows/check_dataflow_jobs.yaml
     with:
       jobname: $JOB_NAME
     secrets:
       GCP_DATAFLOW_SERVICE_KEY: ${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}
   update-attrs:
     needs: check-dataflow
-    uses: leap-stc/proto_feedstock/.github/workflows/update_attrs.yaml@chain-jobs
+    uses: ./.github/workflows/update_attrs.yaml
     # I want these to be referenced locally (https://github.blog/changelog/2022-01-25-github-actions-reusable-workflows-can-be-referenced-locally/)
     secrets:
       GCP_DATAFLOW_SERVICE_KEY: ${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}

--- a/.github/workflows/deploy_recipe.yaml
+++ b/.github/workflows/deploy_recipe.yaml
@@ -13,44 +13,51 @@ on:
         default: 'all'
 
 jobs:
-  deploy-recipes:
-    name: deploy-recipes
+  print-job-name:
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v4
-      - name: "Authenticate to Google Cloud"
-        id: "auth"
-        uses: "google-github-actions/auth@v2"
-        with:
-          credentials_json: "${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}"
-      - name: "Install dependencies"
+      - name: "Print Job Name"
         run: |
-          python -m pip install --upgrade pip
-          pip install pangeo-forge-runner
-      - name: "Check if the workflows are there?"
-        run: |
-          ls -la .github/workflows
-      - name: "Deploy recipes"
-        run: |
-          pangeo-forge-runner bake \
-            --repo=${{ github.server_url }}/${{ github.repository }}.git \
-            --ref=${{ github.sha }} \
-            --feedstock-subdir='feedstock' \
-            --Bake.job_name=$JOB_NAME \
-            --Bake.recipe_id=${{ github.event.inputs.recipe_id }} \
-            -f configs/config_dataflow.py
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
-  check-dataflow:
-    needs: deploy-recipes
-    uses: leap-stc/proto_feedstock/.github/workflows/check_dataflow_jobs.yaml@chain-jobs
-    with:
-      jobname: $JOB_NAME
-    secrets:
-      GCP_DATAFLOW_SERVICE_KEY: ${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}
-  update-attrs:
-    needs: check-dataflow
-    uses: leap-stc/proto_feedstock/.github/workflows/update_attrs.yaml@chain-jobs
-    secrets:
-      GCP_DATAFLOW_SERVICE_KEY: ${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}
+          echo "Job Name: $JOB_NAME"
+  # deploy-recipes:
+  #   name: deploy-recipes
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: "Authenticate to Google Cloud"
+  #       id: "auth"
+  #       uses: "google-github-actions/auth@v2"
+  #       with:
+  #         credentials_json: "${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}"
+  #     - name: "Install dependencies"
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         pip install pangeo-forge-runner
+  #     - name: "Check if the workflows are there?"
+  #       run: |
+  #         ls -la .github/workflows
+  #     - name: "Deploy recipes"
+  #       run: |
+  #         pangeo-forge-runner bake \
+  #           --repo=${{ github.server_url }}/${{ github.repository }}.git \
+  #           --ref=${{ github.sha }} \
+  #           --feedstock-subdir='feedstock' \
+  #           --Bake.job_name=$JOB_NAME \
+  #           --Bake.recipe_id=${{ github.event.inputs.recipe_id }} \
+  #           -f configs/config_dataflow.py
+  #       env:
+  #         GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
+  # check-dataflow:
+  #   needs: deploy-recipes
+  #   uses: leap-stc/proto_feedstock/.github/workflows/check_dataflow_jobs.yaml@chain-jobs
+  #   with:
+  #     jobname: $JOB_NAME
+  #   secrets:
+  #     GCP_DATAFLOW_SERVICE_KEY: ${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}
+  # update-attrs:
+  #   needs: check-dataflow
+  #   uses: leap-stc/proto_feedstock/.github/workflows/update_attrs.yaml@chain-jobs
+  #   # I want these to be referenced locally (https://github.blog/changelog/2022-01-25-github-actions-reusable-workflows-can-be-referenced-locally/)
+  #   secrets:
+  #     GCP_DATAFLOW_SERVICE_KEY: ${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}

--- a/.github/workflows/deploy_recipe.yaml
+++ b/.github/workflows/deploy_recipe.yaml
@@ -22,26 +22,26 @@ jobs:
         uses: "google-github-actions/auth@v2"
         with:
           credentials_json: "${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}"
-      - name: "Install dependencies"
-        run: |
-          python -m pip install --upgrade pip
-          pip install pangeo-forge-runner
-      - name: "Deploy recipes"
-        run: |
-          pangeo-forge-runner bake \
-            --repo=${{ github.server_url }}/${{ github.repository }}.git \
-            --ref=${{ github.sha }} \
-            --feedstock-subdir='feedstock' \
-            --Bake.job_name=${{ env.JOB_NAME }} \
-            --Bake.recipe_id=${{ github.event.inputs.recipe_id }} \
-            -f configs/config_dataflow.py
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
+      # - name: "Install dependencies"
+      #   run: |
+      #     python -m pip install --upgrade pip
+      #     pip install pangeo-forge-runner
+      # - name: "Deploy recipes"
+      #   run: |
+      #     pangeo-forge-runner bake \
+      #       --repo=${{ github.server_url }}/${{ github.repository }}.git \
+      #       --ref=${{ github.sha }} \
+      #       --feedstock-subdir='feedstock' \
+      #       --Bake.job_name=${{ env.JOB_NAME }} \
+      #       --Bake.recipe_id=${{ github.event.inputs.recipe_id }} \
+      #       -f configs/config_dataflow.py
+      #   env:
+      #     GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
   check-dataflow:
     needs: deploy-recipes
     uses: ./.github/workflows/check_dataflow_jobs.yaml
     with:
-      jobname: "$JOB_NAME"
+      jobname: ${{ github.event.inputs.recipe_id }}-${{ github.run_id }}-${{ github.run_attempt }}
     secrets:
       GCP_DATAFLOW_SERVICE_KEY: ${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}
   update-attrs:

--- a/.github/workflows/deploy_recipe.yaml
+++ b/.github/workflows/deploy_recipe.yaml
@@ -41,7 +41,7 @@ jobs:
     needs: deploy-recipes
     uses: ./.github/workflows/check_dataflow_jobs.yaml
     with:
-      jobname: $JOB_NAME
+      jobname: ${{ env.JOB_NAME }}
     secrets:
       GCP_DATAFLOW_SERVICE_KEY: ${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}
   update-attrs:

--- a/.github/workflows/deploy_recipe.yaml
+++ b/.github/workflows/deploy_recipe.yaml
@@ -37,16 +37,23 @@ jobs:
       #       -f configs/config_dataflow.py
       #   env:
       #     GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
-  check-dataflow:
-    needs: deploy-recipes
-    uses: ./.github/workflows/check_dataflow_jobs.yaml
-    secrets:
-      GCP_DATAFLOW_SERVICE_KEY: ${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}
-    with:
-      env:
-        JOB_NAME: ${{ github.event.inputs.recipe_id }}-${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Wait for Dataflow jobs to finish
+      # I tried to make this reusable but the fucking thing would not accept env.JOB_NAME as input.
+      # AT that point, screw it, not worth it.
+        run: |
+          jobname="${{ env.JOB_NAME }}"
+          while true; do
+            count=$(gcloud dataflow jobs list --status=active --filter="name:${jobname}" --format="value(id)" | wc -l)
+            echo "Active Dataflow jobs: $count"
+            if [ "$count" -eq "0" ]; then
+              echo "No active Dataflow jobs found."
+              break
+            fi
+            echo "Waiting for Dataflow jobs to finish..."
+            sleep 30
+          done
   update-attrs:
-    needs: check-dataflow
+    needs: deploy-recipes
     uses: ./.github/workflows/update_attrs.yaml
     # I want these to be referenced locally (https://github.blog/changelog/2022-01-25-github-actions-reusable-workflows-can-be-referenced-locally/)
     secrets:

--- a/.github/workflows/deploy_recipe.yaml
+++ b/.github/workflows/deploy_recipe.yaml
@@ -44,11 +44,11 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
   check-dataflow:
     needs: deploy-recipes
-    uses: leap-stc/proto_feedstock/.github/workflows/check_dataflow_jobs.yaml@${{ github.sha }}
+    uses: leap-stc/proto_feedstock/.github/workflows/check_dataflow_jobs.yaml@chain-jobs
     with:
       jobname: $JOB_NAME
     secrets:
       GCP_DATAFLOW_SERVICE_KEY: ${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}
   update-attrs:
     needs: check-dataflow
-    uses: leap-stc/proto_feedstock/.github/workflows/update_attrs.yaml@${{ github.sha }}
+    uses: leap-stc/proto_feedstock/.github/workflows/update_attrs.yaml@chain-jobs

--- a/.github/workflows/deploy_recipe.yaml
+++ b/.github/workflows/deploy_recipe.yaml
@@ -31,28 +31,24 @@ jobs:
       - name: "Check if the workflows are there?"
         run: |
           ls -la .github/workflows
-      # - name: "Deploy recipes"
-      #   run: |
-      #     pangeo-forge-runner bake \
-      #       --repo=${{ github.server_url }}/${{ github.repository }}.git \
-      #       --ref=${{ github.sha }} \
-      #       --feedstock-subdir='feedstock' \
-      #       --Bake.job_name=$JOB_NAME \
-      #       --Bake.recipe_id=${{ github.event.inputs.recipe_id }} \
-      #       -f configs/config_dataflow.py
-      #   env:
-      #     GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
+      - name: "Deploy recipes"
+        run: |
+          pangeo-forge-runner bake \
+            --repo=${{ github.server_url }}/${{ github.repository }}.git \
+            --ref=${{ github.sha }} \
+            --feedstock-subdir='feedstock' \
+            --Bake.job_name=$JOB_NAME \
+            --Bake.recipe_id=${{ github.event.inputs.recipe_id }} \
+            -f configs/config_dataflow.py
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
   check-dataflow:
     needs: deploy-recipes
-    uses: leap-stc/proto_feedstock/.github/workflows/check_dataflow_jobs.yaml@chain-jobs
+    uses: leap-stc/proto_feedstock/.github/workflows/check_dataflow_jobs.yaml@${{ github.sha }}
     with:
       jobname: $JOB_NAME
     secrets:
       GCP_DATAFLOW_SERVICE_KEY: ${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}
-  just-another-job:
+  update-attrs:
     needs: check-dataflow
-    runs-on: ubuntu-latest
-    steps:
-      - name: Just another step
-        run: echo "This is just another step"
-      
+    uses: leap-stc/proto_feedstock/.github/workflows/update_attrs.yaml@${{ github.sha }}

--- a/.github/workflows/deploy_recipe.yaml
+++ b/.github/workflows/deploy_recipe.yaml
@@ -44,7 +44,7 @@ jobs:
       #     GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
   check-dataflow:
     needs: deploy-recipes
-    uses: leap-stc/proto_feedstock/.github/workflows/check_dataflow_jobs.yaml@main
+    uses: leap-stc/proto_feedstock/.github/workflows/check_dataflow_jobs.yaml@chain-jobs
     with:
       jobname: $JOB_NAME
   just-another-job:

--- a/.github/workflows/deploy_recipe.yaml
+++ b/.github/workflows/deploy_recipe.yaml
@@ -13,12 +13,6 @@ on:
         default: 'all'
 
 jobs:
-  print-job-name:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Print Job Name"
-        run: |
-          echo "Job Name: $JOB_NAME"
   deploy-recipes:
     runs-on: ubuntu-latest
     steps:
@@ -38,7 +32,7 @@ jobs:
             --repo=${{ github.server_url }}/${{ github.repository }}.git \
             --ref=${{ github.sha }} \
             --feedstock-subdir='feedstock' \
-            --Bake.job_name=$JOB_NAME \
+            --Bake.job_name=${{ env.JOB_NAME }} \
             --Bake.recipe_id=${{ github.event.inputs.recipe_id }} \
             -f configs/config_dataflow.py
         env:

--- a/.github/workflows/update_attrs.yaml
+++ b/.github/workflows/update_attrs.yaml
@@ -2,6 +2,10 @@ name: Update Attributes from meta.yaml
 
 on:
   workflow_dispatch:
+  workflow_call:
+    secrets:
+      GCP_DATAFLOW_SERVICE_KEY:
+        required: true
 
 jobs:
   update-attrs:


### PR DESCRIPTION
I tried to get fancy and split the checking for dataflow jobs into a reusable workflow, but somehow that is still not as flexible as I wanted. 
I now simply chained this as a another step in the deploy job and call the update attrs afterwards. Works nicely. The workflow submits a recipe, waits until it is done, and then updates the metadata. 