### PR TITLE
Deactivate Copy stage on local run

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The prototype (and future template) of a LEAP-Pangeo feedstock.
 Click on the button on the top left to use this repository as a template for your new feedstock
 <img width="749" alt="image" src="https://github.com/leap-stc/proto_feedstock/assets/14314623/c786b2c7-adf1-4d4c-9811-0c7a1aa9228c">
 
-Name your feedstock according to your data  `<your_data>_feedstock`. 
+Name your feedstock according to your data  `<your_data>_feedstock`.
 
 Now you can locally check out the repository.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Name your feedstock according to your data  `<your_data>_feedstock`.
 
 >[!WARNING]
 > - Make sure to create the repo under the `leap-stc` github organization, not your personal account! If you already did that, you can always transfer the ownership afterwards.
-> - Name your feedstock according to your data  `<your_data>_feedstock`. 
+> - Name your feedstock according to your data  `<your_data>_feedstock`.
 
 Now you can locally check out the repository.
 

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -3,10 +3,8 @@ A synthetic prototype recipe
 """
 
 import os
-from typing import List, Dict, Any
 from typing import List, Dict
 import apache_beam as beam
-from datetime import datetime, timezone
 from leap_data_management_utils.data_management_transforms import Copy, InjectAttrs
 from pangeo_forge_recipes.patterns import pattern_from_file_sequence
 from pangeo_forge_recipes.transforms import (
@@ -23,6 +21,7 @@ yaml = YAML(typ="safe")
 # load the global config values (we will have to decide where these ultimately live)
 catalog_meta = yaml.load(open("feedstock/catalog.yaml"))
 
+
 def find_recipe_meta(catalog_meta: List[Dict[str, str]], r_id: str) -> Dict[str, str]:
     # Iterate over each dictionary in the list
     for d in catalog_meta:
@@ -33,6 +32,7 @@ def find_recipe_meta(catalog_meta: List[Dict[str, str]], r_id: str) -> Dict[str,
         f"Could not find {r_id=}. Got the following recipe_ids: {[d['id'] for d in catalog_meta]}"
     )
     return None  # Return None if no matching dictionary is found
+
 
 if os.getenv("GITHUB_ACTIONS") == "true":
     print("Running inside GitHub Actions.")

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -20,7 +20,6 @@ from ruamel.yaml import YAML
 
 yaml = YAML(typ="safe")
 
-
 # copied from cmip feedstock (TODO: move to central repo?)
 @dataclass
 class Copy(beam.PTransform):
@@ -34,11 +33,15 @@ class Copy(beam.PTransform):
         # We do need the gs:// prefix?
         # TODO: Determine this dynamically from zarr.storage.FSStore
         source = f"gs://{os.path.normpath(store.path)}/"  # FIXME more elegant. `.copytree` needs trailing slash
-        fs = gcsfs.GCSFileSystem()  # FIXME: How can we generalize this?
-        fs.cp(source, self.target, recursive=True)
-        # return a new store with the new path that behaves exactly like the input
-        # to this stage (so we can slot this stage right before testing/logging stages)
-        return zarr.storage.FSStore(self.target)
+        if self.target is False:
+            # dont do anything
+            return store
+        else:
+            fs = gcsfs.GCSFileSystem()  # FIXME: How can we generalize this?
+            fs.cp(source, self.target, recursive=True)
+            # return a new store with the new path that behaves exactly like the input
+            # to this stage (so we can slot this stage right before testing/logging stages)
+            return zarr.storage.FSStore(self.target)
 
     def expand(self, pcoll: beam.PCollection) -> beam.PCollection:
         return pcoll | "Copying Store" >> beam.Map(self._copy)
@@ -60,11 +63,25 @@ class InjectAttrs(beam.PTransform):
     ) -> beam.PCollection[zarr.storage.FSStore]:
         return pcoll | "Injecting Attributes" >> beam.Map(self._update_zarr_attrs)
 
+def get_pangeo_forge_build_attrs()-> dict[str, Any]:
+    """Get build information (git hash and time) to add to the recipe output"""
+    # Set up injection attributes
+    # This is for demonstration purposes only and should be discussed with the broader LEAP/PGF community
+    # - Bake in information from the top level of the meta.yaml
+    # - Add a timestamp
+    # - Add the git hash
+    # - Add link to the meta.yaml on main
+    # - Add the recipe id
+
+    git_url_hash = f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}/commit/{os.environ['GITHUB_SHA']}"
+    timestamp = datetime.now(timezone.utc).isoformat()
+    
+    return {
+        "pangeo_forge_build_git_hash": git_url_hash,
+        "pangeo_forge_build_timestamp": timestamp,
+    }
 
 # TODO: Both these stages are generally useful. They should at least be in the utils package, maybe in recipes?
-
-# load the global config values (we will have to decide where these ultimately live)
-catalog_meta = yaml.load(open("feedstock/catalog.yaml"))
 
 
 def find_recipe_meta(catalog_meta: List[Dict[str, str]], r_id: str) -> Dict[str, str]:
@@ -78,22 +95,27 @@ def find_recipe_meta(catalog_meta: List[Dict[str, str]], r_id: str) -> Dict[str,
     )
     return None  # Return None if no matching dictionary is found
 
+# load the global config values (we will have to decide where these ultimately live)
+catalog_meta = yaml.load(open("feedstock/catalog.yaml"))
 
-# Set up injection attributes
-# This is for demonstration purposes only and should be discussed with the broader LEAP/PGF community
-# - Bake in information from the top level of the meta.yaml
-# - Add a timestamp
-# - Add the git hash
-# - Add link to the meta.yaml on main
-# - Add the recipe id
+if os.getenv('GITHUB_ACTIONS') == 'true':
+    print("Running inside GitHub Actions.")
 
-git_url_hash = f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}/commit/{os.environ['GITHUB_SHA']}"
-timestamp = datetime.now(timezone.utc).isoformat()
-
-injection_attrs = {
-    "pangeo_forge_build_git_hash": git_url_hash,
-    "pangeo_forge_build_timestamp": timestamp,
-}
+    # Get final store path from catalog.yaml input
+    target_small = find_recipe_meta(catalog_meta["stores"], "small")["url"]
+    target_large = find_recipe_meta(catalog_meta["stores"], "large")["url"]
+    pgf_build_attrs = get_pangeo_forge_build_attrs()
+else:
+    print("Running locally. Deactivating final copy stage.")
+    # this deactivates the final copy stage for local testing execution
+    target_small = False
+    target_large = False
+    pgf_build_attrs = {}
+    
+print("Final output locations")
+print(f"{target_small=}")
+print(f"{target_large=}")
+print(f"{pgf_build_attrs=}")
 
 ## Monthly version
 input_urls_a = [
@@ -108,11 +130,7 @@ input_urls_b = [
 pattern_a = pattern_from_file_sequence(input_urls_a, concat_dim="time")
 pattern_b = pattern_from_file_sequence(input_urls_b, concat_dim="time")
 
-print(f"{catalog_meta=}")
-target_small = find_recipe_meta(catalog_meta["stores"], "small")["url"]
-target_large = find_recipe_meta(catalog_meta["stores"], "large")["url"]
-print(f"{target_small=}")
-print(f"{target_large=}")
+
 
 # small recipe
 small = (
@@ -126,7 +144,7 @@ small = (
         # Maybe its better to find another way and avoid injections entirely...
         combine_dims=pattern_a.combine_dim_keys,
     )
-    | InjectAttrs(injection_attrs)
+    | InjectAttrs(pgf_build_attrs)
     | ConsolidateDimensionCoordinates()
     | ConsolidateMetadata()
     | Copy(target=target_small)
@@ -141,7 +159,7 @@ large = (
         store_name="large.zarr",
         combine_dims=pattern_b.combine_dim_keys,
     )
-    | InjectAttrs(injection_attrs)
+    | InjectAttrs(pgf_build_attrs)
     | ConsolidateDimensionCoordinates()
     | ConsolidateMetadata()
     | Copy(target=target_large)

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -33,6 +33,24 @@ def find_recipe_meta(catalog_meta: List[Dict[str, str]], r_id: str) -> Dict[str,
     )
     return None  # Return None if no matching dictionary is found
 
+def get_pangeo_forge_build_attrs() -> dict[str, Any]:
+    """Get build information (git hash and time) to add to the recipe output"""
+    # Set up injection attributes
+    # This is for demonstration purposes only and should be discussed with the broader LEAP/PGF community
+    # - Bake in information from the top level of the meta.yaml
+    # - Add a timestamp
+    # - Add the git hash
+    # - Add link to the meta.yaml on main
+    # - Add the recipe id
+
+    git_url_hash = f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}/commit/{os.environ['GITHUB_SHA']}"
+    timestamp = datetime.now(timezone.utc).isoformat()
+
+    return {
+        "pangeo_forge_build_git_hash": git_url_hash,
+        "pangeo_forge_build_timestamp": timestamp,
+    }
+
 
 if os.getenv("GITHUB_ACTIONS") == "true":
     print("Running inside GitHub Actions.")

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -20,6 +20,7 @@ from ruamel.yaml import YAML
 
 yaml = YAML(typ="safe")
 
+
 # copied from cmip feedstock (TODO: move to central repo?)
 @dataclass
 class Copy(beam.PTransform):
@@ -63,7 +64,8 @@ class InjectAttrs(beam.PTransform):
     ) -> beam.PCollection[zarr.storage.FSStore]:
         return pcoll | "Injecting Attributes" >> beam.Map(self._update_zarr_attrs)
 
-def get_pangeo_forge_build_attrs()-> dict[str, Any]:
+
+def get_pangeo_forge_build_attrs() -> dict[str, Any]:
     """Get build information (git hash and time) to add to the recipe output"""
     # Set up injection attributes
     # This is for demonstration purposes only and should be discussed with the broader LEAP/PGF community
@@ -75,11 +77,12 @@ def get_pangeo_forge_build_attrs()-> dict[str, Any]:
 
     git_url_hash = f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}/commit/{os.environ['GITHUB_SHA']}"
     timestamp = datetime.now(timezone.utc).isoformat()
-    
+
     return {
         "pangeo_forge_build_git_hash": git_url_hash,
         "pangeo_forge_build_timestamp": timestamp,
     }
+
 
 # TODO: Both these stages are generally useful. They should at least be in the utils package, maybe in recipes?
 
@@ -95,10 +98,11 @@ def find_recipe_meta(catalog_meta: List[Dict[str, str]], r_id: str) -> Dict[str,
     )
     return None  # Return None if no matching dictionary is found
 
+
 # load the global config values (we will have to decide where these ultimately live)
 catalog_meta = yaml.load(open("feedstock/catalog.yaml"))
 
-if os.getenv('GITHUB_ACTIONS') == 'true':
+if os.getenv("GITHUB_ACTIONS") == "true":
     print("Running inside GitHub Actions.")
 
     # Get final store path from catalog.yaml input
@@ -111,7 +115,7 @@ else:
     target_small = False
     target_large = False
     pgf_build_attrs = {}
-    
+
 print("Final output locations")
 print(f"{target_small=}")
 print(f"{target_large=}")
@@ -129,7 +133,6 @@ input_urls_b = [
 
 pattern_a = pattern_from_file_sequence(input_urls_a, concat_dim="time")
 pattern_b = pattern_from_file_sequence(input_urls_b, concat_dim="time")
-
 
 
 # small recipe

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -5,7 +5,7 @@ A synthetic prototype recipe
 import zarr
 import os
 from dataclasses import dataclass
-from typing import List, Dict
+from typing import List, Dict, Any
 import apache_beam as beam
 from datetime import datetime, timezone
 from pangeo_forge_recipes.patterns import pattern_from_file_sequence

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -33,6 +33,7 @@ def find_recipe_meta(catalog_meta: List[Dict[str, str]], r_id: str) -> Dict[str,
     )
     return None  # Return None if no matching dictionary is found
 
+
 def get_pangeo_forge_build_attrs() -> dict[str, Any]:
     """Get build information (git hash and time) to add to the recipe output"""
     # Set up injection attributes

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -3,8 +3,9 @@ A synthetic prototype recipe
 """
 
 import os
-from typing import List, Dict
+from typing import List, Dict, Any
 import apache_beam as beam
+from datetime import datetime, timezone
 from leap_data_management_utils.data_management_transforms import Copy, InjectAttrs
 from pangeo_forge_recipes.patterns import pattern_from_file_sequence
 from pangeo_forge_recipes.transforms import (

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import List, Dict, Any
 import apache_beam as beam
 from datetime import datetime, timezone
+from leap_data_management_utils.data_management_transforms import Copy, InjectAttrs
 from pangeo_forge_recipes.patterns import pattern_from_file_sequence
 from pangeo_forge_recipes.transforms import (
     OpenURLWithFSSpec,
@@ -19,73 +20,6 @@ from pangeo_forge_recipes.transforms import (
 from ruamel.yaml import YAML
 
 yaml = YAML(typ="safe")
-
-
-# copied from cmip feedstock (TODO: move to central repo?)
-@dataclass
-class Copy(beam.PTransform):
-    target: str
-
-    def _copy(self, store: zarr.storage.FSStore) -> zarr.storage.FSStore:
-        import os
-        import zarr
-        import gcsfs
-
-        # We do need the gs:// prefix?
-        # TODO: Determine this dynamically from zarr.storage.FSStore
-        source = f"gs://{os.path.normpath(store.path)}/"  # FIXME more elegant. `.copytree` needs trailing slash
-        if self.target is False:
-            # dont do anything
-            return store
-        else:
-            fs = gcsfs.GCSFileSystem()  # FIXME: How can we generalize this?
-            fs.cp(source, self.target, recursive=True)
-            # return a new store with the new path that behaves exactly like the input
-            # to this stage (so we can slot this stage right before testing/logging stages)
-            return zarr.storage.FSStore(self.target)
-
-    def expand(self, pcoll: beam.PCollection) -> beam.PCollection:
-        return pcoll | "Copying Store" >> beam.Map(self._copy)
-
-
-@dataclass
-class InjectAttrs(beam.PTransform):
-    inject_attrs: dict
-
-    def _update_zarr_attrs(self, store: zarr.storage.FSStore) -> zarr.storage.FSStore:
-        # TODO: Can we get a warning here if the store does not exist?
-        attrs = zarr.open(store, mode="a").attrs
-        attrs.update(self.inject_attrs)
-        # ? Should we consolidate here? We are explicitly doing that later...
-        return store
-
-    def expand(
-        self, pcoll: beam.PCollection[zarr.storage.FSStore]
-    ) -> beam.PCollection[zarr.storage.FSStore]:
-        return pcoll | "Injecting Attributes" >> beam.Map(self._update_zarr_attrs)
-
-
-def get_pangeo_forge_build_attrs() -> dict[str, Any]:
-    """Get build information (git hash and time) to add to the recipe output"""
-    # Set up injection attributes
-    # This is for demonstration purposes only and should be discussed with the broader LEAP/PGF community
-    # - Bake in information from the top level of the meta.yaml
-    # - Add a timestamp
-    # - Add the git hash
-    # - Add link to the meta.yaml on main
-    # - Add the recipe id
-
-    git_url_hash = f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}/commit/{os.environ['GITHUB_SHA']}"
-    timestamp = datetime.now(timezone.utc).isoformat()
-
-    return {
-        "pangeo_forge_build_git_hash": git_url_hash,
-        "pangeo_forge_build_timestamp": timestamp,
-    }
-
-
-# TODO: Both these stages are generally useful. They should at least be in the utils package, maybe in recipes?
-
 
 def find_recipe_meta(catalog_meta: List[Dict[str, str]], r_id: str) -> Dict[str, str]:
     # Iterate over each dictionary in the list

--- a/feedstock/requirements.txt
+++ b/feedstock/requirements.txt
@@ -1,4 +1,4 @@
 pangeo-forge-recipes==0.10.7
 apache-beam[gcp]
 gcsfs
-leap-data-management-utils==0.0.3
+git+https://github.com/leap-stc/leap-data-management-utils.git@copy-stage-pass-through

--- a/feedstock/requirements.txt
+++ b/feedstock/requirements.txt
@@ -1,4 +1,4 @@
 pangeo-forge-recipes==0.10.7
 apache-beam[gcp]
 gcsfs
-git+https://github.com/leap-stc/leap-data-management-utils.git@copy-stage-pass-through
+leap-data-management-utils==0.0.4


### PR DESCRIPTION
The idea here is that the copy stage should take special input (here `target=False`) to not do anything at all. With this we can ensure that the user can still test the recipe locally (where the target might not be available to write). 

- [x] Manual test with `leap-data...@copy-stage-pass-through` --> https://github.com/leap-stc/proto_feedstock/pull/27#issuecomment-2061995912
- [x] Merge https://github.com/leap-stc/leap-data-management-utils/pull/22, release `v0.0.4` and pin that here in `requirements.txt`